### PR TITLE
Default dolby static config is set to none to resolve pop noise issue at the beginning.

### DIFF
--- a/21593SDK05_Core1/src/System/Framework/Main_Core1.c
+++ b/21593SDK05_Core1/src/System/Framework/Main_Core1.c
@@ -73,6 +73,7 @@ void main()
 
 	#ifdef BEO_Framework
 
+#ifndef BEO_NONE
 	Frmwk.Spi.PARAMETER_1 = 0x0030;
 	Tx_Rx_Mode_Command();
 
@@ -122,6 +123,7 @@ void main()
 	Frmwk.Spi.PARAMETER_13 = 0x0820;
 	Frmwk.Spi.PARAMETER_14 = 0x0820;
 	DAP_OARI_Command();
+#endif
 
 	SportInitialize_Command();
 #if defined (BEO_PCM_SPDIF) || defined (BEO_DDP)

--- a/21593SDK05_Core1/src/System/Include/Commn.h
+++ b/21593SDK05_Core1/src/System/Include/Commn.h
@@ -13,7 +13,8 @@ agree to the terms of the associated Analog Devices License Agreement.
 #ifndef COMMN_H
 #define COMMN_H
 
-#define BEO_PCM_I2S
+#define BEO_NONE
+//#define BEO_PCM_I2S
 //#define BEO_MCPCM
 //#define BEO_MAT
 //#define BEO_PCM_SPDIF

--- a/21593SDK05_Core1/src/System/Include/Commn.h
+++ b/21593SDK05_Core1/src/System/Include/Commn.h
@@ -13,6 +13,7 @@ agree to the terms of the associated Analog Devices License Agreement.
 #ifndef COMMN_H
 #define COMMN_H
 
+//Static Configuration
 #define BEO_NONE
 //#define BEO_PCM_I2S
 //#define BEO_MCPCM


### PR DESCRIPTION
Changes are done not to configure DSP in PCM or any other static config by default to resolve the pop noise issue observed the first time after power off - on device.